### PR TITLE
Add password reset feature

### DIFF
--- a/conf.php
+++ b/conf.php
@@ -10,7 +10,7 @@ $settings = array();
 // Database settings
 $settings['serverName'] = "localhost"; // name of the DB server
 $settings['userName'] = "spotlister"; // name of the DB user
-$settings['password'] = "test"; // password of the DB user
+$settings['password'] = 'password'; // password of the DB user
 $settings['dbName'] = "spotlister"; // name of the DB
 
 // Non-critical settings

--- a/profile.php
+++ b/profile.php
@@ -18,11 +18,15 @@
         closeConn($stmt, $conn);
 
         $passwordFromForm = trim($_POST["password"]);
+        $validationResult = validateRegister("usertest", $passwordFromForm);
+        $validationNewResult = validateRegister("usertest", $newPassword);
         if (!password_verify($passwordFromForm, $hashedPassword)) {
             $error = "Your old password does not match.";
         }
-        elseif (validateRegister("user", $passwordFromForm)){
-            $error = validateRegister("user", $passwordFromForm);
+        elseif ($validationResult !== true) {
+            $error = validateRegister("usertest", $passwordFromForm);
+        } elseif ($validationNewResult !== true) {
+            $error = validateRegister("usertest", $newPassword);
         } else {
             $newPassword = password_hash($_POST["newPassword"], PASSWORD_DEFAULT);
             $conn = startConn();


### PR DESCRIPTION
- Changed default password value in `conf.php`. This is due to avoid confusion and additional work required when setting up the web app locally (following the described guide in `README.md`)
- Added a password reset feature in `edituser.php` which allows an admin to change the password of any account.
- Changed broken `profile.php` password change logic, which was previously incompatible with the way the `validateRegister()` function works, always returning a 1 and doing nothing else.