### PR TITLE
post-dev fixes

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -9,9 +9,12 @@
 
     if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST["id"]) && empty($urlErr) && empty($frequencyErr)) {
         $id = testInput((int)$_POST["id"]);
-        $userId = testInput($_SESSION['userId']);
+        $user_id = testInput($_SESSION['userId']);
+        $url = testInput((string)$_POST["url"]);
+        $frequency = testInput((int)$_POST["frequency"]);
 
         $stmt = $conn->prepare("UPDATE Playlists SET url = ?, frequency = ? WHERE id = ? AND user_id = ?");
+        //die ("UPDATE Playlists SET url = '$url', frequency = $frequency WHERE id = $id AND user_id = $user_id");
         $stmt->bind_param("siii", $url, $frequency, $id, $user_id);
         $stmt->execute();
 

--- a/edit.php
+++ b/edit.php
@@ -14,7 +14,6 @@
         $frequency = testInput((int)$_POST["frequency"]);
 
         $stmt = $conn->prepare("UPDATE Playlists SET url = ?, frequency = ? WHERE id = ? AND user_id = ?");
-        //die ("UPDATE Playlists SET url = '$url', frequency = $frequency WHERE id = $id AND user_id = $user_id");
         $stmt->bind_param("siii", $url, $frequency, $id, $user_id);
         $stmt->execute();
 

--- a/scripts/organizemutagen.py
+++ b/scripts/organizemutagen.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+from mutagen.easyid3 import EasyID3
+
+def organize(input_folder, output_folder):
+    if not os.path.exists(output_folder):
+        os.makedirs(output_folder)
+
+    for root, dirs, files in os.walk(input_folder):
+        for file in files:
+            if file.lower().endswith(('.mp3', '.ogg', '.flac')):
+                file_path = os.path.join(root, file)
+                audiofile = EasyID3(file_path)
+
+                if 'artist' in audiofile and 'album' in audiofile:
+                    artist_name = audiofile['artist'][0].split(',')[0].strip()
+                    album_name = audiofile['album'][0]
+
+                    artist_folder = os.path.join(output_folder, artist_name)
+                    if not os.path.exists(artist_folder):
+                        os.makedirs(artist_folder)
+
+                    if album_name:
+                        album_folder = os.path.join(artist_folder, album_name)
+                    else:
+                        album_folder = os.path.join(artist_folder, "unsorted")
+
+                    if not os.path.exists(album_folder):
+                        os.makedirs(album_folder)
+
+                    output_file_path = os.path.join(album_folder, file)
+
+                    if file_path != output_file_path:
+                        if not os.path.exists(output_file_path):
+                            shutil.copy2(file_path, output_file_path)
+                            print(f"Moved '{file}' to '{artist_name}/{album_name}' folder.")
+                        else:
+                            print(f"Skipped '{file}' as it's already in the correct folder.")
+                            os.remove(file_path)
+                else:
+                    print(f"Skipped '{file}' as it doesn't have complete artist metadata.")
+
+if __name__ == "__main__":
+    input_folder = "/home/muzikantas/unsorted"
+    output_folder = "/home/muzikantas/music"
+    organize(input_folder, output_folder)
+

--- a/scripts/readDB.py
+++ b/scripts/readDB.py
@@ -28,7 +28,7 @@ def initialize_database():
         )
         return conn
     except Exception as e:
-        print(e)
+        print(f"[{get_timestamp()}] {e}")
         exit(1)
 
 def get_spotdl_executable():
@@ -88,6 +88,7 @@ def main():
 
     cursor.close()
     conn.close()
+    print(f"[{get_timestamp()}] DB connection closed. The process is finished!")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixed all the world's problems:
- [Added execution permissions](https://github.com/archlich03/spotlister/commit/763cb5865619159eed9207ceb47f0fe0a7cf8fb6): added `chmod +x`, because that is necessary for the python script to run the file.
- [One time downloads are now also downloaded](https://github.com/archlich03/spotlister/pull/108/commits/f6079913056ca11512e77c82d87874c31b207023): changed the code of the `readDB.py`, so it would always pull the media, unless the media is not yet to be refreshed.
- [Improved formatting of timestamps](https://github.com/archlich03/spotlister/pull/108/commits/1efe7e8243e0bb8573d1c1fb904b75c557371e46): Added a function `get_timestamp()`, which is used to cleanly format time, when printing console logs (`1705663905.053763` now looks like `2024-01-19 13:44:33`).
- [Improved log verbosity](https://github.com/archlich03/spotlister/pull/108/commits/66ba9d113adb0c8d229d653a36d1e4f5db461b88): Improved console print when a failure connecting to DB is encountered to the new format. The script now also prints when the script has finished running.
- [Included the base organization file](https://github.com/archlich03/spotlister/pull/108/commits/aca42a03c4f6decf4c0fb973f611f6d6623d78d1): Included `organizemutagen.py` to the repo, since it will be used when creating an image of the project.
- [Fixed editing playlists (again)](https://github.com/archlich03/spotlister/pull/108/commits/b735b17b12a7317964e96c3d5b3ec43a08005ac0): code is self explanitory. The `$user_id` var was reversed in some commit, which stopped the system from functioning properly. Also, defined as to what `$url` and `$frequency` do (previously they were just empty strings.